### PR TITLE
Configure HTTP Request Factory to be used with RestTemplate

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,32 @@ file, or WP-API's `plugin.php`:
     }
     add_filter( 'rest_query_vars', 'my_allow_meta_query' );
     
+# Controlling HTTP Connection behavior
+
+If needed, `org.springframework.http.client.ClientHttpRequestFactory` can be provided to control the HTTP connection behavior. Below example shows how to disable SSL verification when invoking https wordpress endpoints.
+
+
+		TrustStrategy acceptingTrustStrategy = (X509Certificate[] chain, String authType) -> true;
+		
+		SSLContext sslContext = org.apache.http.ssl.SSLContexts.custom()
+		        .loadTrustMaterial(null, acceptingTrustStrategy)
+		        .build();
+
+		SSLConnectionSocketFactory csf = new SSLConnectionSocketFactory(sslContext);
+
+		CloseableHttpClient httpClient = HttpClients.custom()
+		        .setSSLSocketFactory(csf)
+		        .build();
+
+		HttpComponentsClientHttpRequestFactory requestFactory =
+		        new HttpComponentsClientHttpRequestFactory();
+
+		requestFactory.setHttpClient(httpClient);
+		
+		boolean debug = false;
+
+		final Wordpress client = ClientFactory.fromConfig(ClientConfig.of(httpsBaseURL, username, password, debug, requestFactory));
+
 
 # TODO
 

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -38,6 +38,7 @@ import org.springframework.http.HttpMethod;
 import org.springframework.http.MediaType;
 import org.springframework.http.RequestEntity;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.client.ClientHttpRequestFactory;
 import org.springframework.http.converter.ByteArrayHttpMessageConverter;
 import org.springframework.http.converter.HttpMessageConverter;
 import org.springframework.http.converter.ResourceHttpMessageConverter;
@@ -105,6 +106,10 @@ public class Client implements Wordpress {
     }
 
     public Client(String baseUrl, String username, String password, boolean debug) {
+       this(baseUrl, username, password, debug, null);
+    }
+    
+    public Client(String baseUrl, String username, String password, boolean debug, ClientHttpRequestFactory requestFactory) {
         this.baseUrl = baseUrl;
         this.username = username;
         this.password = password;
@@ -121,6 +126,11 @@ public class Client implements Wordpress {
         messageConverters.add(new MappingJackson2HttpMessageConverter(emptyArrayAsNullObjectMapper));
         //messageConverters.add(new MappingJackson2HttpMessageConverter());
         restTemplate = new RestTemplate(messageConverters);
+        
+        if(requestFactory != null){;
+        	restTemplate.setRequestFactory(requestFactory);
+        } 
+        
     }
 
     @Override

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/ClientConfig.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/ClientConfig.java
@@ -1,6 +1,7 @@
 package com.afrozaar.wordpress.wpapi.v2.util;
 
 import org.springframework.core.io.Resource;
+import org.springframework.http.client.ClientHttpRequestFactory;
 
 import org.slf4j.LoggerFactory;
 import org.yaml.snakeyaml.Yaml;
@@ -12,6 +13,7 @@ public class ClientConfig {
 
     Wordpress wordpress;
     boolean debug;
+    ClientHttpRequestFactory requestFactory;
 
     public ClientConfig() {
     }
@@ -19,6 +21,11 @@ public class ClientConfig {
     private ClientConfig(boolean debug, Wordpress wordpress) {
         this.debug = debug;
         this.wordpress = wordpress;
+    }
+    private ClientConfig(boolean debug, Wordpress wordpress, ClientHttpRequestFactory requestFactory) {
+        this.debug = debug;
+        this.wordpress = wordpress;
+        this.requestFactory = requestFactory;
     }
 
     public boolean isDebug() {
@@ -36,6 +43,14 @@ public class ClientConfig {
     public void setWordpress(Wordpress wordpress) {
         this.wordpress = wordpress;
     }
+    
+	public ClientHttpRequestFactory getRequestFactory() {
+		return requestFactory;
+	}
+
+	public void setRequestFactory(ClientHttpRequestFactory requestFactory) {
+		this.requestFactory = requestFactory;
+	}
 
     public static ClientConfig load(InputStream inputStream) {
         return new Yaml().loadAs(inputStream, ClientConfig.class);
@@ -48,6 +63,9 @@ public class ClientConfig {
 
     public static ClientConfig of(String baseUrl, String username, String password, boolean debug) {
         return new ClientConfig(debug, new Wordpress(baseUrl, username, password));
+    }
+    public static ClientConfig of(String baseUrl, String username, String password, boolean debug, ClientHttpRequestFactory requestFactory) {
+        return new ClientConfig(debug, new Wordpress(baseUrl, username, password),requestFactory);
     }
 
     public static class Wordpress {

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/ClientFactory.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/ClientFactory.java
@@ -13,6 +13,6 @@ public class ClientFactory {
 
     public static Wordpress fromConfig(ClientConfig config) {
         final ClientConfig.Wordpress wordpress = config.getWordpress();
-        return new Client(wordpress.baseUrl, wordpress.username, wordpress.password, config.debug);
+        return new Client(wordpress.baseUrl, wordpress.username, wordpress.password, config.debug, config.requestFactory);
     }
 }


### PR DESCRIPTION
Closes #17.

This feature allows to create `Wordpress` client by passing in reference of `org.springframework.http.client.ClientHttpRequestFactory`. Consumers will be able to control HTTP connection behavior like SSL handshake. Example is included in README.md.