### PR TITLE
Forward Compatibility with 4.7 and Meta Delete via POST.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
     <artifactId>wp-api-v2-client-java</artifactId>
     <packaging>jar</packaging>
     
-    <version>2.0-beta15</version>
+    <version>2.0-beta15.1-SNAPSHOT</version>
     
     <name>${project.groupId}:${project.artifactId}</name>
     <description>A Java client implementation to the WordPress WP-API v2 plugin.</description>

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -318,10 +318,11 @@ public class Client implements Wordpress {
         }
 
         try {
-            Function<Map, Boolean> expected = map -> Stream.of("endpoints", "methods", "namespace").allMatch(map::containsKey) && ((ArrayList) map.get("methods")).get(0) == "POST";
+            Function<Map, Boolean> expected = map -> nonNull(map) && Stream.of("endpoints", "methods", "namespace").allMatch(map::containsKey) && Objects.equals(((ArrayList) map.get("methods")).get(0), "POST");
 
             final ResponseEntity<Map> responseEntity = doExchange1(Request.META_POST_DELETE, HttpMethod.OPTIONS, Map.class, forExpand(pid, mid), null, null);
-            canDeleteMetaViaPost = responseEntity.getStatusCode().is2xxSuccessful() && expected.apply(responseEntity.getBody());
+            final Map body = responseEntity.getBody();
+            canDeleteMetaViaPost = responseEntity.getStatusCode().is2xxSuccessful() && expected.apply(body);
             LOG.info("Wordpress instance at {} supports deleting meta via POST /posts/:pid/meta/:mid/delete : {}", Client.this.baseUrl, canDeleteMetaViaPost);
             return canDeleteMetaViaPost;
         } catch (Exception jme) {
@@ -329,7 +330,7 @@ public class Client implements Wordpress {
 
             //com.fasterxml.jackson.databind.JsonMappingException: Can not deserialize instance of java.util.LinkedHashMap out of START_ARRAY token
             if (!(jme instanceof JsonMappingException)) {
-                LOG.error("Unexpected exception pinging for POST /posts/:pid/meta/:mid/delete");
+                LOG.error("Unexpected exception pinging for POST /posts/:pid/meta/:mid/delete", jme);
             }
 
             return canDeleteMetaViaPost;

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -27,6 +27,7 @@ import com.afrozaar.wordpress.wpapi.v2.model.Term;
 import com.afrozaar.wordpress.wpapi.v2.model.User;
 import com.afrozaar.wordpress.wpapi.v2.request.Request;
 import com.afrozaar.wordpress.wpapi.v2.request.SearchRequest;
+import com.afrozaar.wordpress.wpapi.v2.response.CustomRenderableParser;
 import com.afrozaar.wordpress.wpapi.v2.response.PagedResponse;
 import com.afrozaar.wordpress.wpapi.v2.util.AuthUtil;
 import com.afrozaar.wordpress.wpapi.v2.util.MavenProperties;
@@ -212,7 +213,7 @@ public class Client implements Wordpress {
 
             uploadMap.add("file", resource);
 
-            return doExchange1(Request.MEDIAS, HttpMethod.POST, Media.class, forExpand(), null, uploadMap).getBody();
+            return CustomRenderableParser.parseMedia(doExchange1(Request.MEDIAS, HttpMethod.POST, String.class, forExpand(), null, uploadMap).getBody());
         } catch (HttpClientErrorException | HttpServerErrorException e) {
             throw WpApiParsedException.of(e);
         }
@@ -244,7 +245,8 @@ public class Client implements Wordpress {
 
     @Override
     public Media getMedia(Long id) {
-        return doExchange1(Request.MEDIA, HttpMethod.GET, Media.class, forExpand(id), null, null).getBody();
+        return CustomRenderableParser.parse(doExchange1(Request.MEDIA, HttpMethod.GET, String.class, forExpand(id), ImmutableMap.of(CONTEXT_, Contexts.EDIT), null).getBody(),
+                Media.class);
     }
 
     @Override

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -28,7 +28,7 @@ import com.afrozaar.wordpress.wpapi.v2.request.SearchRequest;
 import com.afrozaar.wordpress.wpapi.v2.response.PagedResponse;
 import com.afrozaar.wordpress.wpapi.v2.util.AuthUtil;
 import com.afrozaar.wordpress.wpapi.v2.util.MavenProperties;
-import com.afrozaar.wordpress.wpapi.v2.util.Two;
+import com.afrozaar.wordpress.wpapi.v2.util.Tuple2;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
@@ -58,6 +58,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.apache.commons.beanutils.BeanUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -95,7 +96,7 @@ public class Client implements Wordpress {
     private final RestTemplate restTemplate;
     private final Predicate<Link> next = link -> Strings.NEXT.equals(link.getRel());
     private final Predicate<Link> previous = link -> Strings.PREV.equals(link.getRel());
-    private final Two<String, String> userAgentTuple;
+    private final Tuple2<String, String> userAgentTuple;
 
     public final String baseUrl;
     final private String username;
@@ -104,7 +105,7 @@ public class Client implements Wordpress {
 
     {
         Properties properties = MavenProperties.getProperties();
-        userAgentTuple = Two.of("User-Agent", format("%s/%s", properties.getProperty(ARTIFACT_ID), properties.getProperty(VERSION)));
+        userAgentTuple = Tuple2.of("User-Agent", format("%s/%s", properties.getProperty(ARTIFACT_ID), properties.getProperty(VERSION)));
     }
 
     public Client(String baseUrl, String username, String password, boolean debug) {
@@ -787,7 +788,7 @@ public class Client implements Wordpress {
     }
 
     private <T, B> ResponseEntity<T> doExchange0(HttpMethod method, URI uri, Class<T> typeRef, B body, Optional<MediaType> mediaType) {
-        final Two<String, String> authTuple = AuthUtil.authTuple(username, password);
+        final Tuple2<String, String> authTuple = AuthUtil.authTuple(username, password);
         final RequestEntity.BodyBuilder builder = RequestEntity.method(method, uri).header(authTuple.a, authTuple.b).header(userAgentTuple.a, userAgentTuple.b);
 
         mediaType.ifPresent(builder::contentType);

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -227,7 +227,12 @@ public class Client implements Wordpress {
 
     @Override
     public List<Media> getPostMedias(Long postId) {
-        Media[] medias = CustomRenderableParser.parse(doExchange1(Request.MEDIAS, HttpMethod.GET, String.class, forExpand(), ImmutableMap.of("parent", postId), null).getBody(), Media[].class);
+        Media[] medias = CustomRenderableParser.parse(
+                doExchange1(
+                        Request.MEDIAS, HttpMethod.GET, String.class, forExpand(),
+                        ImmutableMap.of("parent", postId, CONTEXT_, Contexts.EDIT), null
+                ).getBody(),
+                Media[].class);
         return Arrays.asList(medias);
     }
 

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -227,7 +227,7 @@ public class Client implements Wordpress {
 
     @Override
     public List<Media> getPostMedias(Long postId) {
-        Media[] medias = doExchange1(Request.MEDIAS, HttpMethod.GET, Media[].class, forExpand(), ImmutableMap.of("parent", postId), null).getBody();
+        Media[] medias = CustomRenderableParser.parse(doExchange1(Request.MEDIAS, HttpMethod.GET, String.class, forExpand(), ImmutableMap.of("parent", postId), null).getBody(), Media[].class);
         return Arrays.asList(medias);
     }
 

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/api/PostMetas.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/api/PostMetas.java
@@ -21,5 +21,5 @@ public interface PostMetas {
 
     boolean deletePostMeta(Long postId, Long metaId);
 
-    boolean deletePostMeta(Long postId, Long metaId, boolean force);
+    boolean deletePostMeta(Long postId, Long metaId, Boolean force);
 }

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/config/ClientConfig.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/config/ClientConfig.java
@@ -1,4 +1,4 @@
-package com.afrozaar.wordpress.wpapi.v2.util;
+package com.afrozaar.wordpress.wpapi.v2.config;
 
 import org.springframework.core.io.Resource;
 

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/config/ClientFactory.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/config/ClientFactory.java
@@ -1,4 +1,4 @@
-package com.afrozaar.wordpress.wpapi.v2.util;
+package com.afrozaar.wordpress.wpapi.v2.config;
 
 import com.afrozaar.wordpress.wpapi.v2.Client;
 import com.afrozaar.wordpress.wpapi.v2.Wordpress;

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/model/Media.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/model/Media.java
@@ -1,11 +1,13 @@
 package com.afrozaar.wordpress.wpapi.v2.model;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import java.util.Map;
 
 @JsonInclude(JsonInclude.Include.NON_NULL)
+@JsonIgnoreProperties(ignoreUnknown = true)
 public class Media {
 
     @JsonProperty("id")

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/request/Request.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/request/Request.java
@@ -19,6 +19,7 @@ public abstract class Request {
 
     public static final String METAS = "/posts/{postId}/meta";
     public static final String META = "/posts/{postId}/meta/{metaId}";
+    public static final String META_POST_DELETE = "/posts/{postId}/meta/{metaId}/delete";
     public static final String TAXONOMIES = "/taxonomies";
     public static final String TAXONOMY = "/taxonomies/{slug}";
     public static final String TERMS = "/terms/{taxonomySlug}";

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/response/CustomRenderableParser.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/response/CustomRenderableParser.java
@@ -1,0 +1,80 @@
+package com.afrozaar.wordpress.wpapi.v2.response;
+
+import com.afrozaar.wordpress.wpapi.v2.model.Media;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.Spliterator;
+import java.util.Spliterators;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import java.util.stream.StreamSupport;
+
+/**
+ * Utility class that is able to handle the recent change where WP 4.7 now has {@code raw} and {@code rendered} fields for some display fields.
+ * <p>
+ * This class is temporary for the purpose of transitioning between 4.6 and 4.7.
+ */
+public final class CustomRenderableParser {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CustomRenderableParser.class);
+    private static ObjectMapper objectMapper = new ObjectMapper();
+    private static final Set<String> modifiableFields = new HashSet<>(Arrays.asList("description", "caption"));
+
+    private CustomRenderableParser() {
+        // Make other classes unable to instantiate.
+    }
+
+    public static Media parseMedia(String stringResponse) throws HttpClientErrorException {
+        return parse(stringResponse, Media.class);
+    }
+
+    public static <T> T parse(String response, Class<T> clazz) {
+        LOG.debug("Parsing response for {}", clazz);
+        try {
+            final JsonNode jsonNode = objectMapper.readValue(response, JsonNode.class);
+
+            renderableFieldsFrom(jsonNode)
+                    .filter(modifiableFields::contains)
+                    .forEach(renderableField -> ((ObjectNode) jsonNode).put(renderableField, jsonNode.get(renderableField).get("raw").asText()));
+
+            return objectMapper.convertValue(jsonNode, clazz);
+        } catch (IOException e) {
+            LOG.error("Error ", e);
+            throw new HttpClientErrorException(HttpStatus.I_AM_A_TEAPOT, "There was an error parsing the response body.", response.getBytes(), StandardCharsets.UTF_8);
+        }
+    }
+
+    private static Stream<String> renderableFieldsFrom(JsonNode jsonNode0) {
+        final Function<JsonNode, Stream<String>> findRenderableFields = jsonNode -> stream(jsonNode)
+                .filter(entry -> entry.getValue().fields().hasNext())
+                .filter(entry -> stream(entry.getValue().fields())
+                        .filter(field -> "raw".equals(field.getKey()) || "rendered".equals(field.getKey()))
+                        .count() > 0)
+                .map(Map.Entry::getKey);
+        return findRenderableFields.apply(jsonNode0);
+    }
+
+    private static Stream<Map.Entry<String, JsonNode>> stream(JsonNode node) {
+        return stream(node.fields());
+    }
+
+    private static Stream<Map.Entry<String, JsonNode>> stream(Iterator<Map.Entry<String, JsonNode>> iterator) {
+        return StreamSupport.stream(Spliterators.spliteratorUnknownSize(iterator, Spliterator.ORDERED), false);
+    }
+}

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/response/CustomRenderableParser.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/response/CustomRenderableParser.java
@@ -1,5 +1,7 @@
 package com.afrozaar.wordpress.wpapi.v2.response;
 
+import static java.util.Optional.ofNullable;
+
 import com.afrozaar.wordpress.wpapi.v2.model.Media;
 
 import org.springframework.http.HttpStatus;
@@ -75,5 +77,8 @@ public final class CustomRenderableParser {
 
     private static final Consumer<JsonNode> transformNode = node -> findRenderableFields.apply(node)
             .filter(modifiableFields::contains)
-            .forEach(renderableField -> ((ObjectNode) node).put(renderableField, node.get(renderableField).get("raw").asText()));
+            .forEach(
+                    renderableField -> ofNullable(node.get(renderableField).get("raw"))
+                            .ifPresent(raw -> ((ObjectNode) node).put(renderableField, raw.asText()))
+            );
 }

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/AuthUtil.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/AuthUtil.java
@@ -10,16 +10,16 @@ public class AuthUtil {
 
     public static HttpHeaders createHeaders(String username, String password) {
         HttpHeaders httpHeaders = new HttpHeaders();
-        final Two<String, String> authHeader = authTuple(username, password);
+        final Tuple2<String, String> authHeader = authTuple(username, password);
         httpHeaders.set(authHeader.a, authHeader.b);
         httpHeaders.setContentType(MediaType.APPLICATION_JSON);
 
         return httpHeaders;
     }
 
-    public static Two<String, String> authTuple(String username, String password) {
+    public static Tuple2<String, String> authTuple(String username, String password) {
         final byte[] encodedAuth = Base64.getEncoder().encode((username + ":" + password).getBytes());
-        return Two.of("Authorization", "Basic " + new String(encodedAuth));
+        return Tuple2.of("Authorization", "Basic " + new String(encodedAuth));
     }
 
     public static HttpEntity<String> basicAuth(String username, String password) {

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/Tuple2.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/Tuple2.java
@@ -1,15 +1,15 @@
 package com.afrozaar.wordpress.wpapi.v2.util;
 
-public class Two<A, B> {
+public class Tuple2<A, B> {
     public final A a;
     public final B b;
 
-    public Two(A a, B b) {
+    private Tuple2(A a, B b) {
         this.a = a;
         this.b = b;
     }
 
-    public static <A, B> Two<A, B> of(A a, B b) {
-        return new Two<>(a, b);
+    public static <A, B> Tuple2<A, B> of(A a, B b) {
+        return new Tuple2<>(a, b);
     }
 }

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientLiveIT.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientLiveIT.java
@@ -1,8 +1,5 @@
 package com.afrozaar.wordpress.wpapi.v2;
 
-import static org.junit.Assert.*;
-import static org.assertj.core.api.Assertions.assertThat;
-
 import static com.afrozaar.wordpress.wpapi.v2.api.Taxonomies.CATEGORY;
 import static com.afrozaar.wordpress.wpapi.v2.model.builder.ContentBuilder.aContent;
 import static com.afrozaar.wordpress.wpapi.v2.model.builder.ExcerptBuilder.anExcerpt;
@@ -13,11 +10,18 @@ import static com.afrozaar.wordpress.wpapi.v2.model.builder.TermBuilder.aTerm;
 import static com.afrozaar.wordpress.wpapi.v2.model.builder.TitleBuilder.aTitle;
 import static com.afrozaar.wordpress.wpapi.v2.model.builder.UserBuilder.aUser;
 import static com.afrozaar.wordpress.wpapi.v2.request.SearchRequest.Builder.aSearchRequest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import static org.junit.Assert.fail;
+
 import static java.lang.String.format;
 import static org.apache.commons.lang.RandomStringUtils.randomAlphabetic;
 
 import com.afrozaar.wordpress.wpapi.v2.api.Contexts;
 import com.afrozaar.wordpress.wpapi.v2.api.Posts;
+import com.afrozaar.wordpress.wpapi.v2.config.ClientConfig;
+import com.afrozaar.wordpress.wpapi.v2.config.ClientFactory;
 import com.afrozaar.wordpress.wpapi.v2.exception.PageNotFoundException;
 import com.afrozaar.wordpress.wpapi.v2.exception.PostCreateException;
 import com.afrozaar.wordpress.wpapi.v2.exception.TermNotFoundException;
@@ -35,8 +39,6 @@ import com.afrozaar.wordpress.wpapi.v2.model.builder.UserBuilder;
 import com.afrozaar.wordpress.wpapi.v2.request.Request;
 import com.afrozaar.wordpress.wpapi.v2.request.SearchRequest;
 import com.afrozaar.wordpress.wpapi.v2.response.PagedResponse;
-import com.afrozaar.wordpress.wpapi.v2.util.ClientConfig;
-import com.afrozaar.wordpress.wpapi.v2.util.ClientFactory;
 import com.afrozaar.wordpress.wpapi.v2.util.Two;
 
 import org.springframework.core.io.ClassPathResource;

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientLiveIT.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientLiveIT.java
@@ -39,7 +39,7 @@ import com.afrozaar.wordpress.wpapi.v2.model.builder.UserBuilder;
 import com.afrozaar.wordpress.wpapi.v2.request.Request;
 import com.afrozaar.wordpress.wpapi.v2.request.SearchRequest;
 import com.afrozaar.wordpress.wpapi.v2.response.PagedResponse;
-import com.afrozaar.wordpress.wpapi.v2.util.Two;
+import com.afrozaar.wordpress.wpapi.v2.util.Tuple2;
 
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.core.io.Resource;
@@ -177,7 +177,7 @@ public class ClientLiveIT {
     @Test
     public void testSearchForMetaKey() throws PostCreateException {
 
-        final Two<Post, PostMeta> postWithMeta = newTestPostWithRandomDataWithMeta();
+        final Tuple2<Post, PostMeta> postWithMeta = newTestPostWithRandomDataWithMeta();
 
         final PagedResponse<Post> response = client.search(aSearchRequest(Post.class).withFilter("meta_key", postWithMeta.b.getKey()).build());
 
@@ -261,7 +261,7 @@ public class ClientLiveIT {
     @Test
     public void tesGetMedia() throws WpApiParsedException {
 
-        final Two<Post, Media> postWithMedia = newTestPostWithMedia();
+        final Tuple2<Post, Media> postWithMedia = newTestPostWithMedia();
 
         final Media media = client.getMedia(postWithMedia.b.getId());
 
@@ -309,7 +309,7 @@ public class ClientLiveIT {
 
     @Test
     public void testGetPostMedias() throws WpApiParsedException {
-        final Two<Post, Media> postMediaTwo = newTestPostWithMedia();
+        final Tuple2<Post, Media> postMediaTwo = newTestPostWithMedia();
 
         final List<Media> postMedias = client.getPostMedias(postMediaTwo.a.getId());
 
@@ -319,7 +319,7 @@ public class ClientLiveIT {
     @Test
     public void testGetPostMetas() throws PostCreateException {
         // given
-        final Two<Post, PostMeta> postWithMeta = newTestPostWithRandomDataWithMeta();
+        final Tuple2<Post, PostMeta> postWithMeta = newTestPostWithRandomDataWithMeta();
 
         //when
         final List<PostMeta> postMetas = client.getPostMetas(postWithMeta.a.getId());
@@ -332,7 +332,7 @@ public class ClientLiveIT {
     @Test
     public void testGetPostMeta() throws PostCreateException {
 
-        final Two<Post, PostMeta> postWithMeta = newTestPostWithRandomDataWithMeta();
+        final Tuple2<Post, PostMeta> postWithMeta = newTestPostWithRandomDataWithMeta();
 
         final PostMeta postMeta = client.getPostMeta(postWithMeta.a.getId(), postWithMeta.b.getId());
 
@@ -817,10 +817,10 @@ public class ClientLiveIT {
                 .build();
     }
 
-    private Two<Post, PostMeta> newTestPostWithRandomDataWithMeta() throws PostCreateException {
+    private Tuple2<Post, PostMeta> newTestPostWithRandomDataWithMeta() throws PostCreateException {
         final Post post = client.createPost(newTestPostWithRandomData(), PostStatus.publish);
         final PostMeta meta = client.createMeta(post.getId(), randomAlphabetic(5), randomAlphabetic(10));
-        return Two.of(post, meta);
+        return Tuple2.of(post, meta);
     }
 
     private Media newRandomMedia(Post post) {
@@ -832,12 +832,12 @@ public class ClientLiveIT {
                 .build();
     }
 
-    private Two<Post, Media> newTestPostWithMedia() throws WpApiParsedException {
+    private Tuple2<Post, Media> newTestPostWithMedia() throws WpApiParsedException {
         final Post post = client.createPost(newTestPostWithRandomData(), PostStatus.publish);
 
         Resource resource = new ClassPathResource("/bin/gradient_colormap.jpg");
         final Media mediaItem = client.createMedia(newRandomMedia(post), resource);
 
-        return Two.of(post, mediaItem);
+        return Tuple2.of(post, mediaItem);
     }
 }

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientLiveIT.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientLiveIT.java
@@ -266,6 +266,7 @@ public class ClientLiveIT {
         final Media media = client.getMedia(postWithMedia.b.getId());
 
         assertThat(media).isNotNull();
+        assertThat(media.getDescription()).isEqualTo(postWithMedia.b.getDescription());
 
         LOG.debug("Media: {}", media);
     }

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientWithRequestBuilderTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/ClientWithRequestBuilderTest.java
@@ -1,7 +1,7 @@
 package com.afrozaar.wordpress.wpapi.v2;
 
-import com.afrozaar.wordpress.wpapi.v2.util.ClientConfig;
-import com.afrozaar.wordpress.wpapi.v2.util.ClientFactory;
+import com.afrozaar.wordpress.wpapi.v2.config.ClientConfig;
+import com.afrozaar.wordpress.wpapi.v2.config.ClientFactory;
 
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/GalleryQuoteTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/GalleryQuoteTest.java
@@ -1,6 +1,8 @@
 package com.afrozaar.wordpress.wpapi.v2;
 
 import com.afrozaar.wordpress.wpapi.v2.api.Contexts;
+import com.afrozaar.wordpress.wpapi.v2.config.ClientConfig;
+import com.afrozaar.wordpress.wpapi.v2.config.ClientFactory;
 import com.afrozaar.wordpress.wpapi.v2.exception.PostCreateException;
 import com.afrozaar.wordpress.wpapi.v2.exception.PostNotFoundException;
 import com.afrozaar.wordpress.wpapi.v2.model.Post;
@@ -9,8 +11,6 @@ import com.afrozaar.wordpress.wpapi.v2.model.builder.ContentBuilder;
 import com.afrozaar.wordpress.wpapi.v2.model.builder.ExcerptBuilder;
 import com.afrozaar.wordpress.wpapi.v2.model.builder.PostBuilder;
 import com.afrozaar.wordpress.wpapi.v2.model.builder.TitleBuilder;
-import com.afrozaar.wordpress.wpapi.v2.util.ClientConfig;
-import com.afrozaar.wordpress.wpapi.v2.util.ClientFactory;
 
 import org.junit.Ignore;
 import org.junit.Test;

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/request/ClientUserUnitTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/request/ClientUserUnitTest.java
@@ -1,9 +1,11 @@
 package com.afrozaar.wordpress.wpapi.v2.request;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import org.junit.Test;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Map;
 
 public class ClientUserUnitTest {
@@ -34,5 +36,13 @@ public class ClientUserUnitTest {
     @Test
     public void mapJsonToHashmap() throws IOException {
         Map map = mapper.readValue(json, Map.class);
+    }
+
+    @Test
+    public void deserializeMixedMap() throws IOException {
+        //final Map map = mapper.readValue("{\"namespace\":\"wp\\/v2\",\"methods\":[\"POST\"],\"endpoints\":[{\"methods\":[\"POST\"],\"args\":{\"force\":{\"required\":false,\"default\":false,\"description\":\"Required to be true, as resource does not support trashing.\"}}}]}", Map.class);
+        final Map map = mapper.readValue("[]", Map.class);
+
+        System.out.println("map = " + ((ArrayList) map.get("methods")).get(0));
     }
 }

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/request/ClientUserUnitTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/request/ClientUserUnitTest.java
@@ -40,8 +40,7 @@ public class ClientUserUnitTest {
 
     @Test
     public void deserializeMixedMap() throws IOException {
-        //final Map map = mapper.readValue("{\"namespace\":\"wp\\/v2\",\"methods\":[\"POST\"],\"endpoints\":[{\"methods\":[\"POST\"],\"args\":{\"force\":{\"required\":false,\"default\":false,\"description\":\"Required to be true, as resource does not support trashing.\"}}}]}", Map.class);
-        final Map map = mapper.readValue("[]", Map.class);
+        final Map map = mapper.readValue("{\"namespace\":\"wp\\/v2\",\"methods\":[\"POST\"],\"endpoints\":[{\"methods\":[\"POST\"],\"args\":{\"force\":{\"required\":false,\"default\":false,\"description\":\"Required to be true, as resource does not support trashing.\"}}}]}", Map.class);
 
         System.out.println("map = " + ((ArrayList) map.get("methods")).get(0));
     }

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/response/MediaParserTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/response/MediaParserTest.java
@@ -2,12 +2,14 @@ package com.afrozaar.wordpress.wpapi.v2.response;
 
 import com.afrozaar.wordpress.wpapi.v2.model.Media;
 
+import org.assertj.core.api.Assertions;
 import org.junit.Test;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
+import java.util.Arrays;
 import java.util.stream.Collectors;
 
 public class MediaParserTest {
@@ -30,6 +32,17 @@ public class MediaParserTest {
 
     private String getResourceAsString(String resource) throws IOException, URISyntaxException {
         return Files.readAllLines(Paths.get(MediaParserTest.class.getResource(resource).toURI())).stream().collect(Collectors.joining("\n"));
+    }
+
+    @Test
+    public void parseArrayOfMedia() throws Exception {
+        String mediaArray = getResourceAsString("/json/multi-media-response.json");
+
+        final Media[] parse = CustomRenderableParser.parse(mediaArray, Media[].class);
+
+        System.out.println("parse = " + Arrays.toString(parse));
+
+        Assertions.assertThat(parse[0].getCaption()).isEqualTo("YmWDXWlmDNyITKTplpvndMPyAWcdDdiWpoQZaXKDOwkCTBIQBf");
     }
 
 }

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/response/MediaParserTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/response/MediaParserTest.java
@@ -1,0 +1,35 @@
+package com.afrozaar.wordpress.wpapi.v2.response;
+
+import com.afrozaar.wordpress.wpapi.v2.model.Media;
+
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.stream.Collectors;
+
+public class MediaParserTest {
+
+    @Test
+    public void parse() throws Exception {
+
+        String response_4_7 = getResourceAsString("/json/media-4.7.json");
+
+        final Media parse = CustomRenderableParser.parseMedia(response_4_7);
+
+        System.out.println("parse = " + parse);
+
+        String response_4_6 = getResourceAsString("/json/media-4.6.json");
+
+        final Media media = CustomRenderableParser.parseMedia(response_4_6);
+
+        System.out.println("media = " + media);
+    }
+
+    private String getResourceAsString(String resource) throws IOException, URISyntaxException {
+        return Files.readAllLines(Paths.get(MediaParserTest.class.getResource(resource).toURI())).stream().collect(Collectors.joining("\n"));
+    }
+
+}

--- a/src/test/resources/json/media-4.6.json
+++ b/src/test/resources/json/media-4.6.json
@@ -1,0 +1,79 @@
+{
+  "id": 5219,
+  "date": "2017-01-20T09:33:13",
+  "date_gmt": "2017-01-20T09:33:13",
+  "guid": {
+    "rendered": "http://johan-wp/wp-content/uploads/2017/01/gradient_colormap-1.jpg",
+    "raw": "http://johan-wp/wp-content/uploads/2017/01/gradient_colormap-1.jpg"
+  },
+  "modified": "2017-01-20T09:33:13",
+  "modified_gmt": "2017-01-20T09:33:13",
+  "slug": "ncnqyxupgj",
+  "status": "inherit",
+  "type": "attachment",
+  "link": "http://johan-wp/xfrco/ncnqyxupgj/",
+  "title": {
+    "raw": "ncnQyxUpGJ",
+    "rendered": "ncnQyxUpGJ"
+  },
+  "author": 1,
+  "comment_status": "open",
+  "ping_status": "closed",
+  "meta": {},
+  "alt_text": "image",
+  "caption": "RwdSYKQjVMfAlgAXAOhDZAAQUwGUSHDqLzoRYEbJSNmBBgbrOJ",
+  "description": ".:LH7e&amp;6_KF4p{P)N,PL",
+  "media_type": "image",
+  "mime_type": "image/jpeg",
+  "media_details": {
+    "width": 700,
+    "height": 700,
+    "file": "2017/01/gradient_colormap-1.jpg",
+    "image_meta": {
+      "aperture": "0",
+      "credit": "",
+      "camera": "",
+      "caption": "",
+      "created_timestamp": "0",
+      "copyright": "",
+      "focal_length": "0",
+      "iso": "0",
+      "shutter_speed": "0",
+      "title": "",
+      "orientation": "0",
+      "keywords": []
+    },
+    "sizes": {}
+  },
+  "post": 5218,
+  "source_url": "http://johan-wp/wp-content/uploads/2017/01/gradient_colormap-1.jpg",
+  "_links": {
+    "self": [
+      {
+        "href": "http://johan-wp/wp-json/wp/v2/media/5219"
+      }
+    ],
+    "collection": [
+      {
+        "href": "http://johan-wp/wp-json/wp/v2/media"
+      }
+    ],
+    "about": [
+      {
+        "href": "http://johan-wp/wp-json/wp/v2/types/attachment"
+      }
+    ],
+    "author": [
+      {
+        "embeddable": true,
+        "href": "http://johan-wp/wp-json/wp/v2/users/1"
+      }
+    ],
+    "replies": [
+      {
+        "embeddable": true,
+        "href": "http://johan-wp/wp-json/wp/v2/comments?post=5219"
+      }
+    ]
+  }
+}

--- a/src/test/resources/json/media-4.7.json
+++ b/src/test/resources/json/media-4.7.json
@@ -1,0 +1,86 @@
+{
+  "_links": {
+    "about": [
+      {
+        "href": "http://docker.dev/wp-json/wp/v2/types/attachment"
+      }
+    ],
+    "author": [
+      {
+        "embeddable": true,
+        "href": "http://docker.dev/wp-json/wp/v2/users/1"
+      }
+    ],
+    "collection": [
+      {
+        "href": "http://docker.dev/wp-json/wp/v2/media"
+      }
+    ],
+    "replies": [
+      {
+        "embeddable": true,
+        "href": "http://docker.dev/wp-json/wp/v2/comments?post=193"
+      }
+    ],
+    "self": [
+      {
+        "href": "http://docker.dev/wp-json/wp/v2/media/193"
+      }
+    ]
+  },
+  "alt_text": "image",
+  "author": 1,
+  "caption": {
+    "raw": "voweVaDWUaSyJuxbUbJwChmlCTRbukUVoqpcvAHEqDkDGPDnHQ",
+    "rendered": "<p>voweVaDWUaSyJuxbUbJwChmlCTRbukUVoqpcvAHEqDkDGPDnHQ</p>\n"
+  },
+  "comment_status": "open",
+  "date": "2017-01-20T09:43:31",
+  "date_gmt": "2017-01-20T09:43:31",
+  "description": {
+    "raw": "5v[^O*w>bDrb.8o/\"<@%",
+    "rendered": "<p class=\"attachment\"><a href='http://docker.dev/wp-content/uploads/2017/01/gradient_colormap-1.jpg'><img width=\"300\" height=\"300\" src=\"http://docker.dev/wp-content/uploads/2017/01/gradient_colormap-1.jpg\" class=\"attachment-medium size-medium\" alt=\"image\" /></a></p>\n<p>5v[^O*w>bDrb.8o/&#8221;<@%\n</p>\n"
+  },
+  "guid": {
+    "raw": "http://docker.dev/wp-content/uploads/2017/01/gradient_colormap-1.jpg",
+    "rendered": "http://docker.dev/wp-content/uploads/2017/01/gradient_colormap-1.jpg"
+  },
+  "id": 193,
+  "link": "http://docker.dev/xdprv/lkmkwilslp/",
+  "media_details": {
+    "file": "2017/01/gradient_colormap-1.jpg",
+    "height": 700,
+    "image_meta": {
+      "aperture": "0",
+      "camera": "",
+      "caption": "",
+      "copyright": "",
+      "created_timestamp": "0",
+      "credit": "",
+      "focal_length": "0",
+      "iso": "0",
+      "keywords": [],
+      "orientation": "0",
+      "shutter_speed": "0",
+      "title": ""
+    },
+    "sizes": {},
+    "width": 700
+  },
+  "media_type": "image",
+  "meta": [],
+  "mime_type": "image/jpeg",
+  "modified": "2017-01-20T09:43:31",
+  "modified_gmt": "2017-01-20T09:43:31",
+  "ping_status": "closed",
+  "post": 192,
+  "slug": "lkmkwilslp",
+  "source_url": "http://docker.dev/wp-content/uploads/2017/01/gradient_colormap-1.jpg",
+  "status": "inherit",
+  "template": "",
+  "title": {
+    "raw": "LKMKWIlSLp",
+    "rendered": "LKMKWIlSLp"
+  },
+  "type": "attachment"
+}

--- a/src/test/resources/json/multi-media-response.json
+++ b/src/test/resources/json/multi-media-response.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": 5227,
+    "date": "2017-01-20T11:49:04",
+    "date_gmt": "2017-01-20T11:49:04",
+    "guid": {
+      "rendered": "http:\/\/johan-wp\/wp-content\/uploads\/2017\/01\/gradient_colormap-2.jpg"
+    },
+    "modified": "2017-01-20T11:49:04",
+    "modified_gmt": "2017-01-20T11:49:04",
+    "slug": "winwosblvq",
+    "type": "attachment",
+    "link": "http:\/\/johan-wp\/dubjl__trashed\/winwosblvq\/",
+    "title": {
+      "rendered": "WINwosbLVQ"
+    },
+    "author": 1,
+    "comment_status": "open",
+    "ping_status": "closed",
+    "meta": {},
+    "alt_text": "image",
+    "caption": {
+      "raw": "YmWDXWlmDNyITKTplpvndMPyAWcdDdiWpoQZaXKDOwkCTBIQBf"
+    },
+    "description": {
+      "raw": "Vc8 V9zYB-sXorrzJ&lt;n%"
+    },
+    "media_type": "image",
+    "mime_type": "image\/jpeg",
+    "media_details": {
+      "width": 700,
+      "height": 700,
+      "file": "2017\/01\/gradient_colormap-2.jpg",
+      "image_meta": {
+        "aperture": "0",
+        "credit": "",
+        "camera": "",
+        "caption": "",
+        "created_timestamp": "0",
+        "copyright": "",
+        "focal_length": "0",
+        "iso": "0",
+        "shutter_speed": "0",
+        "title": "",
+        "orientation": "0",
+        "keywords": []
+      },
+      "sizes": {}
+    },
+    "post": 5226,
+    "source_url": "http:\/\/johan-wp\/wp-content\/uploads\/2017\/01\/gradient_colormap-2.jpg",
+    "_links": {
+      "self": [
+        {
+          "href": "http:\/\/johan-wp\/wp-json\/wp\/v2\/media\/5227"
+        }
+      ],
+      "collection": [
+        {
+          "href": "http:\/\/johan-wp\/wp-json\/wp\/v2\/media"
+        }
+      ],
+      "about": [
+        {
+          "href": "http:\/\/johan-wp\/wp-json\/wp\/v2\/types\/attachment"
+        }
+      ],
+      "author": [
+        {
+          "embeddable": true,
+          "href": "http:\/\/johan-wp\/wp-json\/wp\/v2\/users\/1"
+        }
+      ],
+      "replies": [
+        {
+          "embeddable": true,
+          "href": "http:\/\/johan-wp\/wp-json\/wp\/v2\/comments?post=5227"
+        }
+      ]
+    }
+  }
+]


### PR DESCRIPTION
Wordpress 4.7 has breaking changes in that Renderable fields, which previously were only strings. These fields are now replaced with Objects with the fields `raw` and `rendered`.

NOTE: This is a temporary forward compatibility workaround, and full support for 4.7 will be added in due time.
