### PR TITLE
Verify that the resource provided when creating media, provides a filename.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
 
     <groupId>com.afrozaar.wordpress</groupId>
     <artifactId>wp-api-v2-client-java</artifactId>
-    <version>4.8.1</version>
+    <version>4.8.2-SNAPSHOT</version>
 
     <packaging>jar</packaging>
 

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/Client.java
@@ -232,6 +232,8 @@ public class Client implements Wordpress {
     @SuppressWarnings("unchecked")
     @Override
     public Media createMedia(Media media, Resource resource) throws WpApiParsedException {
+        Objects.requireNonNull(resource.getFilename(), "The resource used to create a media item does not provide a filename. Please supply a Resource that overrides getFilename().");
+
         try {
             final MultiValueMap<String, Object> uploadMap = new LinkedMultiValueMap<>();
             BiConsumer<String, Object> p = (index, value) -> ofNullable(value).ifPresent(v -> uploadMap.add(index, v));

--- a/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/FilenameWrapperByteArrayResource.java
+++ b/src/main/java/com/afrozaar/wordpress/wpapi/v2/util/FilenameWrapperByteArrayResource.java
@@ -1,0 +1,22 @@
+package com.afrozaar.wordpress.wpapi.v2.util;
+
+import org.springframework.core.io.ByteArrayResource;
+
+public class FilenameWrapperByteArrayResource extends ByteArrayResource {
+    final String fileName;
+
+    public FilenameWrapperByteArrayResource(byte[] byteArray, String fileName) {
+        super(byteArray);
+        this.fileName = fileName;
+    }
+
+    public FilenameWrapperByteArrayResource(byte[] byteArray, String description, String fileName) {
+        super(byteArray, description);
+        this.fileName = fileName;
+    }
+
+    @Override
+    public String getFilename() {
+        return fileName;
+    }
+}

--- a/src/test/java/com/afrozaar/wordpress/wpapi/v2/WordpressClientTest.java
+++ b/src/test/java/com/afrozaar/wordpress/wpapi/v2/WordpressClientTest.java
@@ -2,11 +2,18 @@ package com.afrozaar.wordpress.wpapi.v2;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import static org.junit.Assert.fail;
+
 import com.afrozaar.wordpress.wpapi.v2.config.ClientConfig;
 import com.afrozaar.wordpress.wpapi.v2.config.ClientFactory;
+import com.afrozaar.wordpress.wpapi.v2.exception.WpApiParsedException;
 import com.afrozaar.wordpress.wpapi.v2.model.Post;
+import com.afrozaar.wordpress.wpapi.v2.model.builder.MediaBuilder;
 import com.afrozaar.wordpress.wpapi.v2.model.builder.PostBuilder;
 import com.afrozaar.wordpress.wpapi.v2.model.builder.TitleBuilder;
+import com.afrozaar.wordpress.wpapi.v2.util.FilenameWrapperByteArrayResource;
+
+import org.springframework.core.io.ByteArrayResource;
 
 import org.junit.Test;
 import org.slf4j.Logger;
@@ -44,6 +51,25 @@ public class WordpressClientTest {
 
         LOG.debug("map to post: {}", fieldMap);
 
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void CreateMedia_MustFallOverWhenResourceDoesNotReturnFilename() throws WpApiParsedException {
+        wordpress.createMedia(MediaBuilder.aMedia().build(), new ByteArrayResource(new byte[0]));
+    }
+
+    @Test
+    public void CreateMedia_MustNotFallOverWhenResourceReturnsFileName() throws WpApiParsedException {
+
+
+
+        try {
+            wordpress.createMedia(MediaBuilder.aMedia().build(), new FilenameWrapperByteArrayResource(new byte[0], "myfile.png"));
+        } catch (RuntimeException e) {
+            if (e instanceof NullPointerException) {
+                fail("Did not expect a nullpointer exception");
+            }
+        }
     }
 
 }


### PR DESCRIPTION
When the resource doesn't provide a filename, Wordpress responds with HTTP/400.

This check forces the user to provide a proper resource.

Resolves #43 